### PR TITLE
Pass arguments to spiders

### DIFF
--- a/scrapyrt/decorators.py
+++ b/scrapyrt/decorators.py
@@ -1,0 +1,31 @@
+# -*- coding: utf-8 -*-
+from functools import wraps
+import warnings
+
+from .exceptions import ScrapyrtDeprecationWarning
+
+
+def deprecated(use_instead=None):
+    """This is a decorator which can be used to mark functions
+    as deprecated. It will result in a warning being emitted
+    when the function is used.
+
+    Taken from Scrapy.
+    """
+
+    def deco(func):
+        @wraps(func)
+        def wrapped(*args, **kwargs):
+            message = "Call to deprecated function %s." % func.__name__
+            if use_instead:
+                message += " Use %s instead." % use_instead
+            warnings.warn(message, category=ScrapyrtDeprecationWarning,
+                          stacklevel=2)
+            return func(*args, **kwargs)
+
+        return wrapped
+
+    if callable(use_instead):
+        deco = deco(use_instead)
+        use_instead = None
+    return deco

--- a/scrapyrt/exceptions.py
+++ b/scrapyrt/exceptions.py
@@ -1,0 +1,8 @@
+# -*- coding: utf-8 -*-
+
+
+class ScrapyrtDeprecationWarning(Warning):
+    """Warning category for deprecated features, since the default
+    DeprecationWarning is silenced on Python 2.7+
+    """
+    pass

--- a/scrapyrt/resources.py
+++ b/scrapyrt/resources.py
@@ -163,7 +163,7 @@ class CrawlResource(ServiceResource):
             raise Error('400', message=error_msg)
         return value
 
-    def prepare_crawl(self, request_data, spider_data, **kwargs):
+    def prepare_crawl(self, request_data, spider_data, *args, **kwargs):
         """Schedule given spider with CrawlManager.
 
         :param dict request_data:
@@ -179,17 +179,19 @@ class CrawlResource(ServiceResource):
             max_requests = request_data['max_requests']
         except (KeyError, IndexError):
             max_requests = None
-        dfd = self.run_crawl(spider_name, spider_data, max_requests)
+        dfd = self.run_crawl(
+            spider_name, spider_data, max_requests, *args, **kwargs)
         dfd.addCallback(
-            self.prepare_response, request_data=request_data, **kwargs)
+            self.prepare_response, request_data=request_data, *args, **kwargs)
         return dfd
 
-    def run_crawl(self, spider_name, spider_data, max_requests=None):
+    def run_crawl(self, spider_name, spider_data,
+                  max_requests=None, *args, **kwargs):
         manager = CrawlManager(spider_name, spider_data, max_requests)
-        dfd = manager.crawl()
+        dfd = manager.crawl(*args, **kwargs)
         return dfd
 
-    def prepare_response(self, result, **kwargs):
+    def prepare_response(self, result, *args, **kwargs):
         items = result.get("items")
         response = {
             "status": "ok",

--- a/tests/test_resource_serviceresource.py
+++ b/tests/test_resource_serviceresource.py
@@ -88,7 +88,6 @@ class TestHandleRenderErrors(TestServiceResource):
     def setUp(self):
         super(TestHandleRenderErrors, self).setUp()
 
-
     def test_exception(self, log_err_mock):
         exc = Exception('blah')
         result = self.resource.handle_render_errors(self.request, exc)


### PR DESCRIPTION
This pull request provides a way to pass optional arguments and keyword arguments to crawls. This is internal change, we don't have such an option in current crawl endpoint. We will probably add it in future pull requests.