### PR TITLE
Configurable crawl manager

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -356,6 +356,14 @@ You can pass custom resource here and start Scrapyrt with it.
 
 Default: ``scrapyrt.resources.RealtimeApi``.
 
+CRAWL_MANAGER
+~~~~~~~~~~~~~
+
+Crawl manager that is used to create and control crawl.
+You can override default crawl manager and pass path to custom class here.
+
+Default: ``scrapyrt.core.CrawlManager``.
+
 RESOURCES
 ~~~~~~~~~
 

--- a/scrapyrt/conf/default_settings.py
+++ b/scrapyrt/conf/default_settings.py
@@ -18,6 +18,8 @@ RESOURCES = {
     'crawl.json': 'scrapyrt.resources.CrawlResource',
 }
 
+CRAWL_MANAGER = 'scrapyrt.core.CrawlManager'
+
 # Limit spider run time
 TIMEOUT_LIMIT = 1000
 # disable in production

--- a/scrapyrt/resources.py
+++ b/scrapyrt/resources.py
@@ -187,7 +187,8 @@ class CrawlResource(ServiceResource):
 
     def run_crawl(self, spider_name, spider_data,
                   max_requests=None, *args, **kwargs):
-        manager = CrawlManager(spider_name, spider_data, max_requests)
+        crawl_manager_cls = load_object(settings.CRAWL_MANAGER)
+        manager = crawl_manager_cls(spider_name, spider_data, max_requests)
         dfd = manager.crawl(*args, **kwargs)
         return dfd
 


### PR DESCRIPTION
This PR adds CRAWL_MANAGER setting which can be used to pass custom crawl manager class to the application instead of default one.