### PR TITLE
Fix local tests

### DIFF
--- a/tests/servers.py
+++ b/tests/servers.py
@@ -101,7 +101,7 @@ class BaseTestServer(object):
 
 class ScrapyrtTestServer(BaseTestServer):
 
-    def __init__(self, load_egg=False, *args, **kwargs):
+    def __init__(self, *args, **kwargs):
         super(ScrapyrtTestServer, self).__init__(*args, **kwargs)
         self.arguments = [
             sys.executable, '-m', 'scrapyrt.cmdline', '-p', str(self.port)

--- a/tests/test_resource_crawl.py
+++ b/tests/test_resource_crawl.py
@@ -40,7 +40,7 @@ class TestCrawlResourceGetRequiredArgument(unittest.TestCase):
 class TestCrawlResourceIntegration(unittest.TestCase):
 
     def setUp(self):
-        self.server = ScrapyrtTestServer(load_egg=True)
+        self.server = ScrapyrtTestServer()
         self.server.start()
         self.crawl_url = self.server.url('crawl.json')
         self.site = MockServer()

--- a/tests/test_resource_root.py
+++ b/tests/test_resource_root.py
@@ -8,7 +8,7 @@ from .servers import MockServer, ScrapyrtTestServer
 class TestRootResourceIntegration(unittest.TestCase):
 
     def setUp(self):
-        self.server = ScrapyrtTestServer(load_egg=True)
+        self.server = ScrapyrtTestServer()
         self.server.start()
         self.root_url = self.server.url()
         self.site = MockServer()

--- a/tox.ini
+++ b/tox.ini
@@ -3,4 +3,4 @@ envlist = py27
 
 [testenv]
 deps = -rrequirements-dev.txt
-commands = py.test
+commands = py.test tests


### PR DESCRIPTION
Locally tests were failing with error message:

```
____________________________________________________________________________ TestCrawlResourceIntegration.test_no_spider_name ____________________________________________________________________________

self = <tests.test_resource_crawl.TestCrawlResourceIntegration testMethod=test_no_spider_name>

    def setUp(self):
>       self.server = ScrapyrtTestServer(load_egg=True)

build/lib.linux-x86_64-2.7/tests/test_resource_crawl.py:43:
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _
build/lib.linux-x86_64-2.7/tests/servers.py:114: in __init__
    source, self.cwd, ignore=shutil.ignore_patterns('*.pyc'))
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _

src = '/vagrant/workspace/scrapinghub/repo/scrapyrt/build/lib.linux-x86_64-2.7/tests/sample_data/testproject', dst = '/tmp/tmpLDX8wM/testproject', symlinks = False
ignore = <function _ignore_patterns at 0x7f61c62f61b8>

    def copytree(src, dst, symlinks=False, ignore=None):
        """Recursively copy a directory tree using copy2().

        The destination directory must not already exist.
        If exception(s) occur, an Error is raised with a list of reasons.

        If the optional symlinks flag is true, symbolic links in the
        source tree result in symbolic links in the destination tree; if
        it is false, the contents of the files pointed to by symbolic
        links are copied.

        The optional ignore argument is a callable. If given, it
        is called with the `src` parameter, which is the directory
        being visited by copytree(), and `names` which is the list of
        `src` contents, as returned by os.listdir():

            callable(src, names) -> ignored_names

        Since copytree() is called recursively, the callable will be
        called once for each directory that is copied. It returns a
        list of names relative to the `src` directory that should
        not be copied.

        XXX Consider this example code rather than the ultimate tool.

        """
>       names = os.listdir(src)
E       OSError: [Errno 2] No such file or directory: '/vagrant/workspace/scrapinghub/repo/scrapyrt/build/lib.linux-x86_64-2.7/tests/sample_data/testproject'

/usr/lib/python2.7/shutil.py:171: OSError
```

The reason why that happened was `py.test` discovery entering `build/` directory and trying to execute tests there.