### PR TITLE
Fix error handling

### DIFF
--- a/scrapyrt/resources.py
+++ b/scrapyrt/resources.py
@@ -23,13 +23,13 @@ class ServiceResource(resource.Resource, object):
         try:
             result = resource.Resource.render(self, request)
         except Exception as e:
-            result = self.handle_errors(e, request)
+            result = self.handle_error(e, request)
 
         if not isinstance(result, Deferred):
             return self.render_object(result, request)
 
         # deferred result - add appropriate callbacks and errbacks
-        result.addErrback(self.handle_errors, request)
+        result.addErrback(self.handle_error, request)
 
         def finish_request(obj):
             request.write(self.render_object(obj, request))
@@ -38,7 +38,7 @@ class ServiceResource(resource.Resource, object):
         result.addCallback(finish_request)
         return server.NOT_DONE_YET
 
-    def handle_errors(self, exception_or_failure, request):
+    def handle_error(self, exception_or_failure, request):
         """Override this method to add custom exception handling.
 
         :param request: twisted.web.server.Request

--- a/scrapyrt/resources.py
+++ b/scrapyrt/resources.py
@@ -44,7 +44,7 @@ class ServiceResource(resource.Resource, object):
         :param request: twisted.web.server.Request
         :param exception_or_failure: Exception or
             twisted.python.failure.Failure
-        :return: JSON error response
+        :return: dict which will be converted to JSON error response
 
         """
         failure = None

--- a/tests/test_resource_serviceresource.py
+++ b/tests/test_resource_serviceresource.py
@@ -103,7 +103,7 @@ class TestHandleErrors(TestServiceResource):
         try:
             raise Exception('blah')
         except Exception as exc:
-            result = self.resource.handle_errors(exc, self.request)
+            result = self.resource.handle_error(exc, self.request)
         self.assertEqual(self.request.code, 500)
         self.assertEqual(result['message'], exc.message)
         self._assert_log_err_called(log_msg_mock, exc)
@@ -111,28 +111,28 @@ class TestHandleErrors(TestServiceResource):
     def test_failure(self, log_msg_mock):
         exc = Exception('blah')
         failure = Failure(exc)
-        result = self.resource.handle_errors(failure, self.request)
+        result = self.resource.handle_error(failure, self.request)
         self.assertEqual(self.request.code, 500)
         self.assertEqual(result['message'], exc.message)
         self._assert_log_err_called(log_msg_mock, failure)
 
     def test_error_400(self, log_msg_mock):
         exc = Error('400', 'blah_400')
-        result = self.resource.handle_errors(exc, self.request)
+        result = self.resource.handle_error(exc, self.request)
         self.assertEqual(self.request.code, 400)
         self.assertFalse(log_msg_mock.called)
         self.assertEqual(result['message'], exc.message)
 
     def test_error_403(self, log_msg_mock):
         exc = Error('403', 'blah_403')
-        result = self.resource.handle_errors(exc, self.request)
+        result = self.resource.handle_error(exc, self.request)
         self.assertEqual(self.request.code, 403)
         self.assertFalse(log_msg_mock.called)
         self.assertEqual(result['message'], exc.message)
 
     def test_error_not_supported_method(self, log_msg_mock):
         exc = UnsupportedMethod(['GET'])
-        result = self.resource.handle_errors(exc, self.request)
+        result = self.resource.handle_error(exc, self.request)
         self.assertEqual(self.request.code, 405)
         self.assertFalse(log_msg_mock.called)
         self.assertIn('GET', result['message'])

--- a/tests/test_resource_serviceresource.py
+++ b/tests/test_resource_serviceresource.py
@@ -103,7 +103,7 @@ class TestHandleErrors(TestServiceResource):
         try:
             raise Exception('blah')
         except Exception as exc:
-            result = self.resource.handle_errors(self.request, exc)
+            result = self.resource.handle_errors(exc, self.request)
         self.assertEqual(self.request.code, 500)
         self.assertEqual(result['message'], exc.message)
         self._assert_log_err_called(log_msg_mock, exc)
@@ -111,28 +111,28 @@ class TestHandleErrors(TestServiceResource):
     def test_failure(self, log_msg_mock):
         exc = Exception('blah')
         failure = Failure(exc)
-        result = self.resource.handle_errors(self.request, failure)
+        result = self.resource.handle_errors(failure, self.request)
         self.assertEqual(self.request.code, 500)
         self.assertEqual(result['message'], exc.message)
         self._assert_log_err_called(log_msg_mock, failure)
 
     def test_error_400(self, log_msg_mock):
         exc = Error('400', 'blah_400')
-        result = self.resource.handle_errors(self.request, exc)
+        result = self.resource.handle_errors(exc, self.request)
         self.assertEqual(self.request.code, 400)
         self.assertFalse(log_msg_mock.called)
         self.assertEqual(result['message'], exc.message)
 
     def test_error_403(self, log_msg_mock):
         exc = Error('403', 'blah_403')
-        result = self.resource.handle_errors(self.request, exc)
+        result = self.resource.handle_errors(exc, self.request)
         self.assertEqual(self.request.code, 403)
         self.assertFalse(log_msg_mock.called)
         self.assertEqual(result['message'], exc.message)
 
     def test_error_not_supported_method(self, log_msg_mock):
         exc = UnsupportedMethod(['GET'])
-        result = self.resource.handle_errors(self.request, exc)
+        result = self.resource.handle_errors(exc, self.request)
         self.assertEqual(self.request.code, 405)
         self.assertFalse(log_msg_mock.called)
         self.assertIn('GET', result['message'])
@@ -144,7 +144,7 @@ class TestFormatErrorResponse(TestServiceResource):
         code = 400
         self.request.code = code
         exc = Error(str(code), 'blah')
-        response = self.resource.format_error_response(self.request, exc)
+        response = self.resource.format_error_response(exc, self.request)
         self.assertEqual(response['status'], 'error')
         self.assertEqual(response['message'], exc.message)
         self.assertEqual(response['code'], code)

--- a/tests/test_resource_serviceresource.py
+++ b/tests/test_resource_serviceresource.py
@@ -3,6 +3,7 @@ import json
 
 from mock import MagicMock, patch
 from twisted.internet.defer import succeed, fail
+from twisted.python.failure import Failure
 from twisted.web import server
 from twisted.web.error import Error, UnsupportedMethod
 from twisted.web.server import Request
@@ -82,38 +83,58 @@ class TestRender(TestServiceResource):
         self.assertTrue(log_err_mock.called)
 
 
-@patch('scrapyrt.resources.log.err')
-class TestHandleRenderErrors(TestServiceResource):
+@patch('twisted.python.log.msg')
+class TestHandleErrors(TestServiceResource):
 
     def setUp(self):
-        super(TestHandleRenderErrors, self).setUp()
+        super(TestHandleErrors, self).setUp()
 
-    def test_exception(self, log_err_mock):
-        exc = Exception('blah')
-        result = self.resource.handle_render_errors(self.request, exc)
+    def _assert_log_err_called(self, log_msg_mock, failure):
+        log_msg_mock.call_count = 1
+        _, kwargs = log_msg_mock.call_args
+        self.assertEqual(kwargs['isError'], 1)
+        self.assertEqual(kwargs['system'], 'scrapyrt')
+        if isinstance(failure, Failure):
+            self.assertEqual(kwargs['failure'], failure)
+        else:
+            self.assertEqual(kwargs['failure'].value, failure)
+
+    def test_exception(self, log_msg_mock):
+        try:
+            raise Exception('blah')
+        except Exception as exc:
+            result = self.resource.handle_errors(self.request, exc)
         self.assertEqual(self.request.code, 500)
-        log_err_mock.assert_called_once_with()
         self.assertEqual(result['message'], exc.message)
+        self._assert_log_err_called(log_msg_mock, exc)
 
-    def test_error_400(self, log_err_mock):
+    def test_failure(self, log_msg_mock):
+        exc = Exception('blah')
+        failure = Failure(exc)
+        result = self.resource.handle_errors(self.request, failure)
+        self.assertEqual(self.request.code, 500)
+        self.assertEqual(result['message'], exc.message)
+        self._assert_log_err_called(log_msg_mock, failure)
+
+    def test_error_400(self, log_msg_mock):
         exc = Error('400', 'blah_400')
-        result = self.resource.handle_render_errors(self.request, exc)
+        result = self.resource.handle_errors(self.request, exc)
         self.assertEqual(self.request.code, 400)
-        self.assertFalse(log_err_mock.called)
+        self.assertFalse(log_msg_mock.called)
         self.assertEqual(result['message'], exc.message)
 
-    def test_error_403(self, log_err_mock):
+    def test_error_403(self, log_msg_mock):
         exc = Error('403', 'blah_403')
-        result = self.resource.handle_render_errors(self.request, exc)
+        result = self.resource.handle_errors(self.request, exc)
         self.assertEqual(self.request.code, 403)
-        self.assertFalse(log_err_mock.called)
+        self.assertFalse(log_msg_mock.called)
         self.assertEqual(result['message'], exc.message)
 
-    def test_error_not_supported_method(self, log_err_mock):
+    def test_error_not_supported_method(self, log_msg_mock):
         exc = UnsupportedMethod(['GET'])
-        result = self.resource.handle_render_errors(self.request, exc)
+        result = self.resource.handle_errors(self.request, exc)
         self.assertEqual(self.request.code, 405)
-        self.assertFalse(log_err_mock.called)
+        self.assertFalse(log_msg_mock.called)
         self.assertIn('GET', result['message'])
 
 


### PR DESCRIPTION
Fixes #3 

- Renamed [handle_render_errors](/scrapinghub/scrapyrt/blob/db7cd9069d6d8b15b304e61ceb091ed7d188c527/scrapyrt/resources.py#L43) method to [handle_error](/scrapinghub/scrapyrt/blob/aae91b3da9107c2eb3054c347f45c3a99ef2edfc/scrapyrt/resources.py#L41) - it handles crawl errors as well, not only only render errors
- handle_error accepts exceptions or failures and handles them accordingly
- changed signature of handle_error - it accepts failure or exception as a first parameter and request as a second one which allows to use it directly as an errback
- changed signature of [format_error_response](/scrapinghub/scrapyrt/blob/db7cd9069d6d8b15b304e61ceb091ed7d188c527/scrapyrt/resources.py#L59) - if follows the same rules as handle_error and render_object (request is second argument)