### PR TITLE
CrawlManager - optional start_requests

### DIFF
--- a/scrapyrt/resources.py
+++ b/scrapyrt/resources.py
@@ -7,7 +7,6 @@ from twisted.web.error import UnsupportedMethod, Error
 import demjson
 
 from . import log
-from .core import CrawlManager
 from .conf import settings
 
 

--- a/tests/test_crawler_process.py
+++ b/tests/test_crawler_process.py
@@ -27,7 +27,7 @@ class CralwerProcessTestCase(unittest.TestCase):
         signals_and_handlers = [
             ('item_scraped', 'get_item'),
             ('item_dropped', 'collect_dropped'),
-            ('spider_opened', 'spider_opened'),
+            ('spider_idle', 'spider_idle'),
             ('spider_error', 'handle_spider_error'),
             ('request_scheduled', 'handle_scheduling'),
         ]


### PR DESCRIPTION
* add attribute to enable/disable start_requests from CrawlManager
* move request scheduling to spider_idle handler as scheduling in spider_open doesn't work well with start requests

It still impossible to enable `start_requests` in ScrapyRT using GET or POST request, this PR is aimed to provide a base for further changes.