### PR TITLE
Close root and crawler log observers

### DIFF
--- a/scrapyrt/core.py
+++ b/scrapyrt/core.py
@@ -86,23 +86,32 @@ class ScrapyrtCrawlerProcess(CrawlerProcess):
 
     def _setup_crawler_logging(self, crawler):
         log_observer = scrapy_log.start_from_crawler(crawler)
-
         if log_observer:
-            # Ugly hack to close log file - monkey patch log_observer.stop
-            # method to close file each time log observer is closed.
-            # I prefer this to be fixed in Scrapy itself, but as
-            # Scrapy is going to switch to standart python logging soon
-            # https://github.com/scrapy/scrapy/pull/1060
-            # this change wouldn't be accepted in preference of merging
-            # new logging sooner.
-            def stop_and_close_log_file(self):
-                self.__stop()
-                self.write.__self__.close()
+            monkey_patch_and_connect_log_observer(crawler, log_observer)
+        if self.log_observer:
+            monkey_patch_and_connect_log_observer(crawler, self.log_observer)
 
-            log_observer.__stop = log_observer.stop
-            log_observer.stop = types.MethodType(
-                stop_and_close_log_file, log_observer)
-            crawler.signals.connect(log_observer.stop, signals.engine_stopped)
+
+def monkey_patch_and_connect_log_observer(crawler, log_observer):
+    """Ugly hack to close log file.
+
+    Monkey patch log_observer.stop method to close file each time
+    log observer is closed.
+    I prefer this to be fixed in Scrapy itself, but as
+    Scrapy is going to switch to standart python logging soon
+    https://github.com/scrapy/scrapy/pull/1060
+    this change wouldn't be accepted in preference of merging
+    new logging sooner.
+
+    """
+    def stop_and_close_log_file(self):
+        self.__stop()
+        self.write.__self__.close()
+
+    log_observer.__stop = log_observer.stop
+    log_observer.stop = types.MethodType(
+        stop_and_close_log_file, log_observer)
+    crawler.signals.connect(log_observer.stop, signals.engine_stopped)
 
 
 class CrawlManager(object):


### PR DESCRIPTION
It appeared that Scrapy creates 2 log observers - for root level logging and for crawler. Those 2 observers open the same file for writing using different file descriptors:

https://github.com/chekunkov/scrapy/blob/master/scrapy/crawler.py#L105
https://github.com/chekunkov/scrapy/blob/master/scrapy/crawler.py#L126

```
$ lsof -c scrapyrt | grep /logs/
lsof: WARNING: can't stat() ext4 file system /var/lib/docker/devicemapper
      Output information may be incomplete.
scrapyrt 11835 vagrant   13w   REG   0,34     2391 15350042 /vagrant/workspace/scrapinghub/proj/brandview-scrapyrt/logs/spiders/walmart.com_products/2015-04-07T08:46:11.605987.log (192.168.33.1:/Users/alex/Dev)
scrapyrt 11835 vagrant   14w   REG   0,34     2391 15350042 /vagrant/workspace/scrapinghub/proj/brandview-scrapyrt/logs/spiders/walmart.com_products/2015-04-07T08:46:11.605987.log (192.168.33.1:/Users/alex/Dev)
```

While #13 fixed things for crawler log observer and added proper closing for log file, root level log observer was untouched and continued to cause issues described in #9. This PR fixes this issue and closes both log file objects on engine_closed.
