### PR TITLE
Handle exception from logobserver on kill

### DIFF
--- a/scrapyrt/core.py
+++ b/scrapyrt/core.py
@@ -91,6 +91,16 @@ class ScrapyrtCrawlerProcess(CrawlerProcess):
         if self.log_observer:
             monkey_patch_and_connect_log_observer(crawler, self.log_observer)
 
+    def _stop_logging(self):
+        if self.log_observer:
+            try:
+                self.log_observer.stop()
+            except ValueError:
+                # exception on kill
+                # exceptions.ValueError: list.remove(x): x not in list
+                # looks like it's safe to ignore it
+                pass
+
 
 def monkey_patch_and_connect_log_observer(crawler, log_observer):
     """Ugly hack to close log file.


### PR DESCRIPTION
If scrapyrt process is killed following exception is raised:

```
	  File "/vagrant/workspace/repositories/scrapy/scrapy/crawler.py", line 141, in _signal_kill
	    self._stop_logging()
	  File "/vagrant/workspace/repositories/scrapy/scrapy/crawler.py", line 160, in _stop_logging
	    self.log_observer.stop()
	  File "/home/vagrant/.env/some-env/local/lib/python2.7/site-packages/twisted/python/log.py", line 416, in stop
	    removeObserver(self.emit)
	  File "/home/vagrant/.env/some-env/local/lib/python2.7/site-packages/twisted/python/log.py", line 167, in removeObserver
	    self.observers.remove(other)
	exceptions.ValueError: list.remove(x): x not in list
```