### PR TITLE
Fix misleading close spider reason

### DIFF
--- a/scrapyrt/core.py
+++ b/scrapyrt/core.py
@@ -221,7 +221,8 @@ class CrawlManager(object):
     def limit_requests(self, spider):
         """Stop crawl after reaching max_requests."""
         if self.max_requests and self.max_requests <= self.request_count:
-            reason = "stop generating requests, only one request allowed"
+            reason = "stop generating requests, only {} requests allowed".format(
+                self.max_requests)
             spider.crawler.engine.close_spider(spider, reason=reason)
         else:
             self.request_count += 1


### PR DESCRIPTION
When `max_requests` limit is reached spider is closed with reason

```
Closing spider (stop generating requests, only one request allowed)
```

and as `max_requests` could be greater then 1 - it should provide exact max number of requests in log message:

```
Closing spider (stop generating requests, only <max_requests> requests allowed)
```