### PR TITLE
Fix encoding issues

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -310,10 +310,10 @@ One more example (don't forget to import random)::
 
     class SpiderName(Spider):
         name = "some_other_spider"
-        
+
         def parse(self, response):
             pass
-        
+
         def modify_realtime_request(self, request):
             UA = [
 	        'Mozilla/5.0 (Windows NT 5.1; rv:31.0) Gecko/20100101 Firefox/31.0',
@@ -460,6 +460,15 @@ LOG_FILE
 Path to file to store logs from Scrapyrt with daily rotation.
 
 Default: ``None``. Writing log to file is disabled by default.
+
+
+LOG_ENCODING
+~~~~~~~~~~~~
+
+Encoding that's used to encode log messages.
+
+Default: ``utf-8``.
+
 
 Spider settings
 ---------------

--- a/scrapyrt/conf/default_settings.py
+++ b/scrapyrt/conf/default_settings.py
@@ -10,6 +10,8 @@ LOG_FILE = None
 # Path to spiders log directory
 LOG_DIR = 'logs'
 
+LOG_ENCODING = 'utf-8'
+
 # Root server resource, should inherit from scrapyrt.resources.RealtimeAPI
 SERVICE_ROOT = 'scrapyrt.resources.RealtimeApi'
 

--- a/scrapyrt/core.py
+++ b/scrapyrt/core.py
@@ -257,7 +257,7 @@ class CrawlManager(object):
         return results
 
     def create_spider_request(self, kwargs):
-        url = kwargs.pop('url')
+        url = kwargs.pop('url').decode('utf-8')
         try:
             req = Request(url, **kwargs)
         except (TypeError, ValueError) as e:

--- a/scrapyrt/core.py
+++ b/scrapyrt/core.py
@@ -257,7 +257,7 @@ class CrawlManager(object):
         return results
 
     def create_spider_request(self, kwargs):
-        url = kwargs.pop('url').decode('utf-8')
+        url = kwargs.pop('url')
         try:
             req = Request(url, **kwargs)
         except (TypeError, ValueError) as e:

--- a/scrapyrt/resources.py
+++ b/scrapyrt/resources.py
@@ -110,8 +110,10 @@ class CrawlResource(ServiceResource):
         At the moment kwargs for scrapy request are not supported in GET.
         They are supported in POST handler.
         """
-        request_data = dict((name, value[0]) for name, value
-                            in request.args.items())
+        request_data = dict(
+            (name.decode('utf-8'), value[0].decode('utf-8'))
+            for name, value in request.args.items()
+        )
 
         spider_data = {
             'url': self.get_required_argument(request_data, 'url'),

--- a/tests/test_log_observer.py
+++ b/tests/test_log_observer.py
@@ -2,9 +2,10 @@
 import StringIO
 
 from mock import patch
+from twisted.python.log import startLoggingWithObserver, removeObserver
 from twisted.trial import unittest
 
-from scrapyrt.log import ScrapyrtFileLogObserver
+from scrapyrt.log import ScrapyrtFileLogObserver, msg
 
 
 @patch('twisted.python.log.FileLogObserver.emit')
@@ -13,7 +14,11 @@ class TestLogObserver(unittest.TestCase):
     def setUp(self):
         self.file = StringIO.StringIO()
         self.log_observer = ScrapyrtFileLogObserver(self.file)
+        startLoggingWithObserver(self.log_observer.emit, setStdout=False)
         self.event_dict = {'system': 'scrapyrt', 'message': 'blah'}
+
+    def tearDown(self):
+        removeObserver(self.log_observer.emit)
 
     def test_emit_called(self, emit_mock):
         self.log_observer.emit(self.event_dict)
@@ -33,3 +38,9 @@ class TestLogObserver(unittest.TestCase):
         self.event_dict['system'] = 'other'
         self.log_observer.emit(self.event_dict)
         self.assertTrue(emit_mock.called)
+
+    def test_unicode_message(self, emit_mock):
+        original_message = u'Привет, мир!'
+        msg(original_message)
+        transformed_message = emit_mock.call_args[0][1]['message'][0]
+        self.assertEqual(transformed_message, original_message.encode('utf-8'))


### PR DESCRIPTION
This PR provides better Unicode support for ScrapyRT.

Fixed issues:

1) Twisted logging doesn't work well with Unicode messages

`msg(u'http://ko.wikipedia.org/wiki/위키백과:대문')`

```
2015-06-04 09:24:25+0000 [scrapyrt] <unicode instance at 0x7f91117634e0 with str error:
	 Traceback (most recent call last):
	  File "/home/vagrant/.env/scrapyrt/local/lib/python2.7/site-packages/twisted/python/reflect.py", line 391, in _safeFormat
	    return formatter(o)
	UnicodeEncodeError: 'ascii' codec can't encode characters in position 29-32: ordinal not in range(128)
```

2) `UnicodeDecodeError` is raised if url contains unicode characters: 

`http://ko.wikipedia.org/wiki/위키백과:대문`

```
	  File "/vagrant/workspace/scrapinghub/repo/scrapyrt/scrapyrt/core.py", line 278, in create_spider_request
	    msg = msg.format(self.spider_name, url, repr(kwargs))
	exceptions.UnicodeDecodeError: 'ascii' codec can't decode byte 0xd0 in position 29: ordinal not in range(128)
```