### PR TITLE
Use port-for library to select random port for mock server

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -5,3 +5,4 @@ requests
 mock
 pytest
 pytest-cov
+port-for

--- a/tests/servers.py
+++ b/tests/servers.py
@@ -9,8 +9,10 @@ import sys
 import tempfile
 import time
 
+import port_for
+
 from . import TESTS_PATH
-from .utils import get_ephemeral_port, get_testenv
+from .utils import get_testenv
 
 DEVNULL = open(os.devnull, 'wb')
 SAMPLE_DATA = os.path.join(TESTS_PATH, 'sample_data')
@@ -21,7 +23,7 @@ class BaseTestServer(object):
     def __init__(self, host='localhost', port=None, cwd=None, shell=False,
                  stdin=DEVNULL, stdout=DEVNULL, stderr=DEVNULL):
         self.host = host
-        self.port = port or get_ephemeral_port(self.host)
+        self.port = port or port_for.select_random()
         self.proc = None
         self.shell = shell
         self.cwd = cwd

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -15,12 +15,6 @@ def get_testenv():
     return env
 
 
-def get_ephemeral_port(host=''):
-    s = socket.socket()
-    s.bind((host, 0))
-    return s.getsockname()[1]
-
-
 def get_settings():
     """Settings with all extensions disabled."""
     return Settings({


### PR DESCRIPTION
https://pypi.python.org/pypi/port-for/

Reason behind this change - builds are failing from time to time because mock servers cannot start on ephemeral port, for example https://travis-ci.org/scrapinghub/scrapyrt/builds/65413023