### PR TITLE
Windows Compatible Time Format for Log Filename

### DIFF
--- a/scrapyrt/core.py
+++ b/scrapyrt/core.py
@@ -164,7 +164,7 @@ class CrawlManager(object):
         log_dir = os.path.join(self.log_dir, self.spider_name)
         if not os.path.exists(log_dir):
             os.makedirs(log_dir)
-        filename = datetime.datetime.now().isoformat() + '.log'
+        filename = datetime.datetime.now().strftime('%Y-%m-%dT%H;%M;%S.%f') + '.log'
         return os.path.join(log_dir, filename)
 
     def get_project_settings(self):


### PR DESCRIPTION
`:` is not an acceptable character for Windows file names. I've replaced it with `;` on my branch and scrapyrt now works on Windows by default.
