### PR TITLE
Windows timestamp

### DIFF
--- a/scrapyrt/conf/default_settings.py
+++ b/scrapyrt/conf/default_settings.py
@@ -6,7 +6,7 @@ PROJECT_SETTINGS = None
 
 # Path to server log file
 LOG_FILE = None
-SPIDER_LOGFILE_TIMEFORMAT = '%Y-%m-%dT%H%M.%S.%f'
+SPIDER_LOGFILE_TIMEFORMAT = '%Y-%m-%dT%H%M%S.%f'
 
 # Path to spiders log directory
 LOG_DIR = 'logs'

--- a/scrapyrt/conf/default_settings.py
+++ b/scrapyrt/conf/default_settings.py
@@ -6,6 +6,7 @@ PROJECT_SETTINGS = None
 
 # Path to server log file
 LOG_FILE = None
+SPIDER_LOGFILE_TIMEFORMAT = '%Y-%m-%dT%H%M.%S.%f'
 
 # Path to spiders log directory
 LOG_DIR = 'logs'

--- a/scrapyrt/conf/default_settings.py
+++ b/scrapyrt/conf/default_settings.py
@@ -6,7 +6,10 @@ PROJECT_SETTINGS = None
 
 # Path to server log file
 LOG_FILE = None
-SPIDER_LOGFILE_TIMEFORMAT = '%Y-%m-%dT%H%M%S.%f'
+
+# Spider logs will be kept in file with name set to timestamp in following
+# format
+SPIDER_LOG_FILE_TIMEFORMAT = '%Y-%m-%dT%H%M%S.%f'
 
 # Path to spiders log directory
 LOG_DIR = 'logs'

--- a/scrapyrt/core.py
+++ b/scrapyrt/core.py
@@ -164,7 +164,7 @@ class CrawlManager(object):
         log_dir = os.path.join(self.log_dir, self.spider_name)
         if not os.path.exists(log_dir):
             os.makedirs(log_dir)
-        time_format = settings.SPIDER_LOGFILE_TIMEFORMAT
+        time_format = settings.SPIDER_LOG_FILE_TIMEFORMAT
         filename = datetime.datetime.now().strftime(time_format) + '.log'
         return os.path.join(log_dir, filename)
 

--- a/scrapyrt/core.py
+++ b/scrapyrt/core.py
@@ -164,7 +164,8 @@ class CrawlManager(object):
         log_dir = os.path.join(self.log_dir, self.spider_name)
         if not os.path.exists(log_dir):
             os.makedirs(log_dir)
-        filename = datetime.datetime.now().strftime('%Y-%m-%dT%H;%M;%S.%f') + '.log'
+        time_format = settings.SPIDER_LOGFILE_TIMEFORMAT
+        filename = datetime.datetime.now().strftime(time_format) + '.log'
         return os.path.join(log_dir, filename)
 
     def get_project_settings(self):

--- a/scrapyrt/core.py
+++ b/scrapyrt/core.py
@@ -164,7 +164,7 @@ class CrawlManager(object):
         log_dir = os.path.join(self.log_dir, self.spider_name)
         if not os.path.exists(log_dir):
             os.makedirs(log_dir)
-        filename = datetime.datetime.now().isoformat() + '.log'
+        filename = datetime.datetime.now().strftime('%Y-%m-%dT%H;%M;%S.%f') + '.log'
         return os.path.join(log_dir, filename)
 
     def get_project_settings(self):

--- a/tests/test_crawl_manager.py
+++ b/tests/test_crawl_manager.py
@@ -384,7 +384,7 @@ class TestStartRequests(unittest.TestCase):
 
 class TestCreateProperLogFile(TestCrawlManager):
     def test_filename(self):
-        logdir = tempfile.mkdtemp()
+        logdir = "some_dir_name"
         self.crawl_manager.log_dir = logdir
         path = self.crawl_manager._get_log_file_path()
         filename = os.path.basename(path)

--- a/tests/test_crawl_manager.py
+++ b/tests/test_crawl_manager.py
@@ -1,4 +1,6 @@
 # -*- coding: utf-8 -*-
+import os
+import tempfile
 from time import sleep
 import datetime
 
@@ -378,3 +380,17 @@ class TestStartRequests(unittest.TestCase):
         self.crawl_manager.start_requests = False
         self.crawl_manager.crawl()
         self.assertEqual(self.start_requests_mock.call_count, 0)
+
+
+class TestCreateProperLogFile(TestCrawlManager):
+    def test_filename(self):
+        logdir = tempfile.mkdtemp()
+        self.crawl_manager.log_dir = logdir
+        path = self.crawl_manager._get_log_file_path()
+        filename = os.path.basename(path)
+        expected_format = '%Y-%m-%dT%H%M.%S.%f.log'
+        datetime_object = datetime.datetime.strptime(filename, expected_format)
+        now = datetime.datetime.now()
+        assert datetime_object
+        delta = now - datetime_object
+        assert delta.seconds < 60

--- a/tests/test_crawl_manager.py
+++ b/tests/test_crawl_manager.py
@@ -388,7 +388,7 @@ class TestCreateProperLogFile(TestCrawlManager):
         self.crawl_manager.log_dir = logdir
         path = self.crawl_manager._get_log_file_path()
         filename = os.path.basename(path)
-        expected_format = '%Y-%m-%dT%H%M.%S.%f.log'
+        expected_format = '%Y-%m-%dT%H%M%S.%f.log'
         datetime_object = datetime.datetime.strptime(filename, expected_format)
         now = datetime.datetime.now()
         assert datetime_object

--- a/tests/test_crawl_manager.py
+++ b/tests/test_crawl_manager.py
@@ -1,6 +1,5 @@
 # -*- coding: utf-8 -*-
 import os
-import tempfile
 from time import sleep
 import datetime
 


### PR DESCRIPTION
This is just same as #43 expects it:

* adds unit tests 
* adds way to customize log file timeformat
* goes with format  that contains dots so for example `2016-12-22T145616.839288.log`

cc @zolrath 