### PR TITLE
[Dockerfile] fix docker build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -12,23 +12,16 @@ FROM ubuntu:14.04
 
 ENV DEBIAN_FRONTEND noninteractive
 
-RUN apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv 627220E7
-RUN echo 'deb http://archive.scrapy.org/ubuntu scrapy main' | tee /etc/apt/sources.list.d/scrapy.list
-
 RUN apt-get update && \
-    apt-get install -y python python-dev python-pip \
-    libffi-dev libxml2-dev libxslt1-dev zlib1g-dev libssl-dev
+    apt-get install -y python python-dev  \
+    libffi-dev libxml2-dev libxslt1-dev zlib1g-dev libssl-dev wget
 
 RUN mkdir -p /scrapyrt/src /scrapyrt/project
 RUN mkdir -p /var/log/scrapyrt
 
-WORKDIR /scrapyrt/src
-
-ADD requirements.txt /scrapyrt/src/requirements.txt
-RUN pip install -r requirements.txt
-
-ADD . /scrapyrt/src
-RUN pip install /scrapyrt/src
+RUN wget "https://bootstrap.pypa.io/get-pip.py"
+RUN python get-pip.py
+RUN pip install scrapyrt
 
 WORKDIR /scrapyrt/project
 


### PR DESCRIPTION
it was failing, fixes:

* get pip in recommended way instead of using ubuntu python-pip
* e.g. clean up Dockerfile, no need to install scrapinghub ppa, we install scrapy with pip