### PR TITLE
Travis CI: move "distributions" one level up

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,11 +14,11 @@ script: tox
 
 deploy:
   provider: pypi
+  distributions: sdist bdist_wheel
   user: scrapinghub
   password:
     secure: RBETqFS52ylswbPVF8h7NmkK/bJWnukZw1QgiAIhA5YHwBfWw/U2N6HHHR0sCH6vmm8uWuNZc2nJVmCX0x/fXXLYRAhCYXdXvui+eSYDDB9eAgV7MVA2kF0V4/9jg0x/IYD2p5/YxP2jXa1zDtLt1p450BQu6UPjsCchfiYteyY=
   on:
     tags: true
     condition: $TOXENV == py27 && $TRAVIS_TAG =~ ^[0-9]+[.][0-9]+[.][0-9]+(rc[0-9]+|[.]dev[0-9]+)?$
-    distributions: sdist bdist_wheel
     repo: scrapinghub/scrapyrt


### PR DESCRIPTION
travis cli has a bug on where it puts "distributions":
https://github.com/travis-ci/travis.rb/issues/373