### PR TITLE
Use tox's generative envlist

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,12 +6,19 @@ matrix:
      - python: 2.7
        env: TOXENV=py27
      - python: 2.7
-       env: TOXENV=py27-scrapy1.0.x
+       env: TOXENV=py27-scrapy1.0
+     - python: 2.7
+       env: TOXENV=py27-scrapy1.1
+     - python: 2.7
+       env: TOXENV=py27-scrapy1.2
      - python: 3.5
        env: TOXENV=py35
      - python: 3.6
        env: TOXENV=py36
-
+     - python: 3.6
+       env: TOXENV=py36-scrapy1.1
+     - python: 3.6
+       env: TOXENV=py36-scrapy1.2
 script: tox
 
 deploy:

--- a/tox.ini
+++ b/tox.ini
@@ -1,13 +1,10 @@
 [tox]
-envlist = py27, py27-scrapy1.0.x, py35, py36
+envlist = py27, py27-scrapy{1.0,1.1,1.2}, py35, py36, {py35,py36}-scrapy{1.1,1.2}
 
 [testenv]
 deps =
-    -r{toxinidir}/requirements.txt
+    scrapy1.0: Scrapy>=1.0,<1.1
+    scrapy1.1: Scrapy>=1.1,<1.2
+    scrapy1.2: Scrapy>=1.2,<1.3
     -r{toxinidir}/requirements-dev.txt
 commands = py.test {posargs}
-
-[testenv:py27-scrapy1.0.x]
-deps =
-    Scrapy<1.1
-    -r{toxinidir}/requirements-dev.txt


### PR DESCRIPTION
Test all combinations of Python 2/3 and scrapy 1.0, 1.1, 1.2 and 1.3 branches.

I think we can probably get rid of this extra `-r{toxinidir}/requirements-tox.txt`, and dependencies from setup.py would be used (I added it because of duplicate dependencies on scrapy that tox was complaining about).
I'm far from a tox expert so suggestions are welcome.