### PR TITLE
fix dockerfile entrypoint

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -28,6 +28,6 @@ RUN pip install /scrapyrt/src
 
 WORKDIR /scrapyrt/project
 
-ENTRYPOINT ["scrapyrt", "-i 0.0.0.0"]
+ENTRYPOINT ["scrapyrt", "-i", "0.0.0.0"]
 
 EXPOSE 9080


### PR DESCRIPTION
Took me way too long to figure out why my docker instance was throwing: 

    twisted.internet.error.CannotListenError: Couldn't listen on  0.0.0.0:9080: [Errno -2] Name or service not known

Apparently entrypoint was misconfigured.