### PR TITLE
Extra API parameters passed to the spider's constructor

### DIFF
--- a/docs/source/api.rst
+++ b/docs/source/api.rst
@@ -40,7 +40,7 @@ need to do following things::
 
 This will download Scrapyrt Docker image for you. Next step you need to run this image. Remember
 about providing proper port and project directory. Project directory from host machine must be mounted in
-directory /scrapyrt/project on guest. Following command will launch Scrapyrt forwarding port 9080 from
+directory /scrapyrt/project on guest. Following command will launch Scrapyrt forwarding port 9080 from 
 guest to host, in demonized mode, with project directory in directory /home/user/quotesbot::
 
     docker run -p 9080:9080 -tid -v /home/user/quotesbot:/scrapyrt/project scrapinghub/scrapyrt

--- a/docs/source/api.rst
+++ b/docs/source/api.rst
@@ -130,9 +130,8 @@ start_requests
     behavior. If this argument is present API will execute start_requests
     Spider method.
 
-If required parameters are missing api will return 400 Bad Request
-with hopefully helpful error message.
-Any extra argument is going to be passed to the spider's constructor as kwarg.
+| If required parameters are missing api will return 400 Bad Request with hopefully helpful error message.
+| Any extra argument is going to be passed to the spider's constructor as kwarg.
 
 Examples
 ~~~~~~~~
@@ -217,9 +216,8 @@ url
 
 It can contain all keyword arguments supported by `Scrapy Request`_ class.
 
-If required parameters are missing api will return 400 Bad Request with
-hopefully helpful error message.
-Any extra argument is going to be passed to the spider's constructor as kwarg.
+| If required parameters are missing api will return 400 Bad Request with hopefully helpful error message.
+| Any extra argument is going to be passed to the spider's constructor as kwarg.
 
 Examples
 ~~~~~~~~

--- a/docs/source/api.rst
+++ b/docs/source/api.rst
@@ -40,7 +40,7 @@ need to do following things::
 
 This will download Scrapyrt Docker image for you. Next step you need to run this image. Remember
 about providing proper port and project directory. Project directory from host machine must be mounted in
-directory /scrapyrt/project on guest. Following command will launch Scrapyrt forwarding port 9080 from 
+directory /scrapyrt/project on guest. Following command will launch Scrapyrt forwarding port 9080 from
 guest to host, in demonized mode, with project directory in directory /home/user/quotesbot::
 
     docker run -p 9080:9080 -tid -v /home/user/quotesbot:/scrapyrt/project scrapinghub/scrapyrt
@@ -132,6 +132,7 @@ start_requests
 
 If required parameters are missing api will return 400 Bad Request
 with hopefully helpful error message.
+Any extra argument is going to be passed to the spider's constructor as kwarg.
 
 Examples
 ~~~~~~~~
@@ -218,6 +219,7 @@ It can contain all keyword arguments supported by `Scrapy Request`_ class.
 
 If required parameters are missing api will return 400 Bad Request with
 hopefully helpful error message.
+Any extra argument is going to be passed to the spider's constructor as kwarg.
 
 Examples
 ~~~~~~~~

--- a/scrapyrt/resources.py
+++ b/scrapyrt/resources.py
@@ -111,6 +111,13 @@ class CrawlResource(ServiceResource):
     isLeaf = True
     allowedMethods = ['GET', 'POST']
 
+    # Documented API parameters
+    # NOTE: update this list if an API parameter is added
+    API_PARAMS = [
+        'spider_name', 'url', 'callback', 'errback',
+        'max_requests', 'request', 'start_requests',
+    ]
+
     def render_GET(self, request, **kwargs):
         """Request querysting must contain following keys: url, spider_name.
 
@@ -212,6 +219,12 @@ class CrawlResource(ServiceResource):
             max_requests = api_params['max_requests']
         except (KeyError, IndexError):
             max_requests = None
+
+        crawler_params = api_params.copy()
+        for api_param in self.API_PARAMS:
+            crawler_params.pop(api_param, None)
+        kwargs.update(crawler_params)
+
         dfd = self.run_crawl(
             spider_name, scrapy_request_args, max_requests,
             start_requests=start_requests, *args, **kwargs)

--- a/tests/test_resource_crawl.py
+++ b/tests/test_resource_crawl.py
@@ -109,6 +109,24 @@ class TestCrawlResource(object):
         msg = "'foo' is not a valid argument"
         assert re.search(msg, e.value.message)
 
+    def test_prepare_crawl_extra_attr(self, resource):
+        api_params = {
+            'spider_name': 'test',
+            'request': {'url': 'http://foo.com'},
+            'extra': 'extra_value',
+        }
+        scrapy_request_args = api_params['request'].copy()
+        resource.run_crawl = Mock()
+        with patch('scrapyrt.core.CrawlManager', spec=True) as manager:
+            resource.prepare_crawl(api_params, scrapy_request_args)
+        expected = {'extra': 'extra_value'}
+        spider_name = api_params['spider_name']
+        max_requests = None
+        resource.run_crawl.assert_called_once_with(
+            spider_name, scrapy_request_args, max_requests,
+            start_requests=False, **expected
+        )
+
     @pytest.mark.parametrize('scrapy_args,api_args,has_error', [
         ({'url': 'aa'}, {}, False),
         ({}, {}, True)


### PR DESCRIPTION
Fixes #81.

This PR tries to follow up the approach taken in #72 by adding the improvements that @pawelmhm suggests in his review.

Any extra (not documented) GET/POST parameter is passed to the spider's constructor's kwargs.