### PR TITLE
/resources/ handle bytes in item from spider

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -33,3 +33,4 @@ testing_scripts*
 
 # sphinx
 docs/build/*
+.python-version

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,3 +2,5 @@ Scrapy>=1.0.0
 service-identity>=1.0.0
 demjson==2.2.4
 six==1.12.0
+jmespath==0.10.0
+pyasn1==0.4.8


### PR DESCRIPTION
ScrapyJSONEncoder should not crash if there are bytes in item generated
by spider. Also added error handling, we should not hang when there is
something unexpected in API, just return to 500 and go on.