### PR TITLE
Fix deprecated feature

### DIFF
--- a/tests/test_crawl_manager.py
+++ b/tests/test_crawl_manager.py
@@ -74,7 +74,7 @@ class TestCrawl(TestCrawlManager):
         call_args, call_kwargs = crawler_process_mock.call_args
         for arg in spider_args:
             self.assertIn(arg, call_args)
-        self.assertDictContainsSubset(spider_kwargs, call_kwargs)
+        self.assertEqual(spider_kwargs, call_kwargs)
 
 
 class TestGetProjectSettings(TestCrawlManager):


### PR DESCRIPTION
When we run tests for this project, we get this warning:
```
============================================================================================================ warnings summary =============================================================================================================
tests/test_crawl_manager.py::TestCrawl::test_spider_arguments_are_passed
  /usr/lib/python3.8/unittest/case.py:1215: DeprecationWarning: assertDictContainsSubset is deprecated
    warnings.warn('assertDictContainsSubset is deprecated',
-- Docs: https://docs.pytest.org/en/stable/warnings.html
===================================================================================================== 101 passed, 1 warning in 27.20s =====================================================================================================
```
This PR will fix it. Thank you.